### PR TITLE
Hold SPACE to draw (Paint-style virtual left mouse button)

### DIFF
--- a/crates/drafftink-app/src/app.rs
+++ b/crates/drafftink-app/src/app.rs
@@ -23,7 +23,7 @@ use winit::application::ApplicationHandler;
 use winit::dpi::LogicalSize;
 use winit::event::{ElementState, MouseButton, MouseScrollDelta, WindowEvent};
 use winit::event_loop::{ActiveEventLoop, EventLoop};
-use winit::keyboard::{Key, NamedKey};
+use winit::keyboard::{Key, KeyCode, NamedKey, PhysicalKey};
 use winit::window::{CursorIcon, Window, WindowId};
 
 use crate::event_handler::EventHandler;
@@ -4356,7 +4356,13 @@ impl ApplicationHandler for App {
                 // (Paint-style: press to start, release to finish — uses the
                 // current cursor position). Modifier combos like Ctrl+Space
                 // are left to the regular handler below.
-                if matches!(&event.logical_key, Key::Named(NamedKey::Space))
+                //
+                // Match on `physical_key` (not `logical_key`) so we agree with
+                // `InputState::is_drawing()`, which queries the physical-key
+                // hold state via winit_input_helper. Using the logical key
+                // here would risk the two checks disagreeing on layouts/IMEs
+                // where the space bar's logical output differs.
+                if matches!(event.physical_key, PhysicalKey::Code(KeyCode::Space))
                     && !state.input.ctrl()
                     && !event.repeat
                 {

--- a/crates/drafftink-app/src/app.rs
+++ b/crates/drafftink-app/src/app.rs
@@ -23,7 +23,7 @@ use winit::application::ApplicationHandler;
 use winit::dpi::LogicalSize;
 use winit::event::{ElementState, MouseButton, MouseScrollDelta, WindowEvent};
 use winit::event_loop::{ActiveEventLoop, EventLoop};
-use winit::keyboard::{Key, KeyCode, NamedKey};
+use winit::keyboard::{Key, NamedKey};
 use winit::window::{CursorIcon, Window, WindowId};
 
 use crate::event_handler::EventHandler;
@@ -1485,6 +1485,49 @@ struct AppState {
     needs_redraw: bool,
 }
 
+/// Sync the document to CRDT, broadcast to peers, and flush outgoing
+/// messages to the websocket. No-op when not in a room.
+///
+/// Free function (rather than `&mut self` on `AppState`) so callers can
+/// invoke it inside closures that already hold disjoint borrows of other
+/// fields on `AppState` (e.g. inside the egui closure that borrows
+/// `state.egui_ctx`). Pass the fields directly to keep borrows fine-grained.
+#[cfg(not(target_arch = "wasm32"))]
+fn broadcast_doc_changes(
+    collab: &mut CollaborationManager,
+    document: &drafftink_core::canvas::CanvasDocument,
+    websocket: Option<&drafftink_core::sync::NativeWebSocket>,
+) {
+    if !collab.is_in_room() {
+        return;
+    }
+    collab.sync_to_crdt(document);
+    collab.broadcast_sync();
+    if let Some(ws) = websocket {
+        for msg in collab.take_outgoing() {
+            let _ = ws.send(&msg);
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn broadcast_doc_changes(
+    collab: &mut CollaborationManager,
+    document: &drafftink_core::canvas::CanvasDocument,
+    websocket: Option<&drafftink_core::sync::WasmWebSocket>,
+) {
+    if !collab.is_in_room() {
+        return;
+    }
+    collab.sync_to_crdt(document);
+    collab.broadcast_sync();
+    if let Some(ws) = websocket {
+        for msg in collab.take_outgoing() {
+            let _ = ws.send(&msg);
+        }
+    }
+}
+
 /// Main application struct.
 pub struct App {
     config: AppConfig,
@@ -2316,14 +2359,12 @@ impl ApplicationHandler for App {
                                 // Sync property changes
                                 let has_changes =
                                     applied_to_text_range || !state.canvas.selection.is_empty();
-                                if has_changes && state.collab.is_in_room() {
-                                    state.collab.sync_to_crdt(&state.canvas.document);
-                                    state.collab.broadcast_sync();
-                                    if let Some(ref ws) = state.websocket {
-                                        for msg in state.collab.take_outgoing() {
-                                            let _ = ws.send(&msg);
-                                        }
-                                    }
+                                if has_changes {
+                                    broadcast_doc_changes(
+                                        &mut state.collab,
+                                        &state.canvas.document,
+                                        state.websocket.as_ref(),
+                                    );
                                 }
                             }
                             UiAction::SetFillColor(color) => {
@@ -2338,14 +2379,12 @@ impl ApplicationHandler for App {
                                     }
                                 }
                                 // Sync property changes
-                                if has_selection && state.collab.is_in_room() {
-                                    state.collab.sync_to_crdt(&state.canvas.document);
-                                    state.collab.broadcast_sync();
-                                    if let Some(ref ws) = state.websocket {
-                                        for msg in state.collab.take_outgoing() {
-                                            let _ = ws.send(&msg);
-                                        }
-                                    }
+                                if has_selection {
+                                    broadcast_doc_changes(
+                                        &mut state.collab,
+                                        &state.canvas.document,
+                                        state.websocket.as_ref(),
+                                    );
                                 }
                             }
                             UiAction::SetStrokeWidth(width) => {
@@ -2359,14 +2398,12 @@ impl ApplicationHandler for App {
                                     }
                                 }
                                 // Sync property changes
-                                if has_selection && state.collab.is_in_room() {
-                                    state.collab.sync_to_crdt(&state.canvas.document);
-                                    state.collab.broadcast_sync();
-                                    if let Some(ref ws) = state.websocket {
-                                        for msg in state.collab.take_outgoing() {
-                                            let _ = ws.send(&msg);
-                                        }
-                                    }
+                                if has_selection {
+                                    broadcast_doc_changes(
+                                        &mut state.collab,
+                                        &state.canvas.document,
+                                        state.websocket.as_ref(),
+                                    );
                                 }
                             }
                             UiAction::SaveLocal => {
@@ -2476,15 +2513,11 @@ impl ApplicationHandler for App {
                                     state.canvas.clear_selection();
                                     log::info!("Document cleared");
                                     // Sync changes to collaborators
-                                    if state.collab.is_in_room() {
-                                        state.collab.sync_to_crdt(&state.canvas.document);
-                                        state.collab.broadcast_sync();
-                                        if let Some(ref ws) = state.websocket {
-                                            for msg in state.collab.take_outgoing() {
-                                                let _ = ws.send(&msg);
-                                            }
-                                        }
-                                    }
+                                    broadcast_doc_changes(
+                                        &mut state.collab,
+                                        &state.canvas.document,
+                                        state.websocket.as_ref(),
+                                    );
                                 }
                             }
                             UiAction::ShowIntro => {
@@ -2616,14 +2649,12 @@ impl ApplicationHandler for App {
                                     }
                                 }
                                 // Sync property changes
-                                if has_selection && state.collab.is_in_room() {
-                                    state.collab.sync_to_crdt(&state.canvas.document);
-                                    state.collab.broadcast_sync();
-                                    if let Some(ref ws) = state.websocket {
-                                        for msg in state.collab.take_outgoing() {
-                                            let _ = ws.send(&msg);
-                                        }
-                                    }
+                                if has_selection {
+                                    broadcast_doc_changes(
+                                        &mut state.collab,
+                                        &state.canvas.document,
+                                        state.websocket.as_ref(),
+                                    );
                                 }
                             }
                             UiAction::SetExportScale(scale) => {
@@ -2651,14 +2682,12 @@ impl ApplicationHandler for App {
                                 }
                                 log::info!("Sloppiness: {:?}", sloppiness);
                                 // Sync property changes
-                                if has_selection && state.collab.is_in_room() {
-                                    state.collab.sync_to_crdt(&state.canvas.document);
-                                    state.collab.broadcast_sync();
-                                    if let Some(ref ws) = state.websocket {
-                                        for msg in state.collab.take_outgoing() {
-                                            let _ = ws.send(&msg);
-                                        }
-                                    }
+                                if has_selection {
+                                    broadcast_doc_changes(
+                                        &mut state.collab,
+                                        &state.canvas.document,
+                                        state.websocket.as_ref(),
+                                    );
                                 }
                             }
                             UiAction::SetFillPattern(level) => {
@@ -2682,14 +2711,12 @@ impl ApplicationHandler for App {
                                     }
                                 }
                                 log::info!("Fill pattern: {:?}", fill_pattern);
-                                if has_selection && state.collab.is_in_room() {
-                                    state.collab.sync_to_crdt(&state.canvas.document);
-                                    state.collab.broadcast_sync();
-                                    if let Some(ref ws) = state.websocket {
-                                        for msg in state.collab.take_outgoing() {
-                                            let _ = ws.send(&msg);
-                                        }
-                                    }
+                                if has_selection {
+                                    broadcast_doc_changes(
+                                        &mut state.collab,
+                                        &state.canvas.document,
+                                        state.websocket.as_ref(),
+                                    );
                                 }
                             }
                             UiAction::SetPathStyle(level) => {
@@ -2727,14 +2754,12 @@ impl ApplicationHandler for App {
                                 }
                                 log::info!("PathStyle: {:?}", path_style);
                                 // Sync property changes
-                                if has_selection && state.collab.is_in_room() {
-                                    state.collab.sync_to_crdt(&state.canvas.document);
-                                    state.collab.broadcast_sync();
-                                    if let Some(ref ws) = state.websocket {
-                                        for msg in state.collab.take_outgoing() {
-                                            let _ = ws.send(&msg);
-                                        }
-                                    }
+                                if has_selection {
+                                    broadcast_doc_changes(
+                                        &mut state.collab,
+                                        &state.canvas.document,
+                                        state.websocket.as_ref(),
+                                    );
                                 }
                             }
                             UiAction::SetStrokeStyle(level) => {
@@ -2763,14 +2788,12 @@ impl ApplicationHandler for App {
                                 }
                                 log::info!("StrokeStyle: {:?}", stroke_style);
                                 // Sync property changes
-                                if has_selection && state.collab.is_in_room() {
-                                    state.collab.sync_to_crdt(&state.canvas.document);
-                                    state.collab.broadcast_sync();
-                                    if let Some(ref ws) = state.websocket {
-                                        for msg in state.collab.take_outgoing() {
-                                            let _ = ws.send(&msg);
-                                        }
-                                    }
+                                if has_selection {
+                                    broadcast_doc_changes(
+                                        &mut state.collab,
+                                        &state.canvas.document,
+                                        state.websocket.as_ref(),
+                                    );
                                 }
                             }
                             UiAction::Undo => {
@@ -2778,15 +2801,11 @@ impl ApplicationHandler for App {
                                     state.canvas.clear_selection();
                                     log::info!("Undo performed");
                                     // Sync changes to collaborators
-                                    if state.collab.is_in_room() {
-                                        state.collab.sync_to_crdt(&state.canvas.document);
-                                        state.collab.broadcast_sync();
-                                        if let Some(ref ws) = state.websocket {
-                                            for msg in state.collab.take_outgoing() {
-                                                let _ = ws.send(&msg);
-                                            }
-                                        }
-                                    }
+                                    broadcast_doc_changes(
+                                        &mut state.collab,
+                                        &state.canvas.document,
+                                        state.websocket.as_ref(),
+                                    );
                                 } else {
                                     log::info!("Nothing to undo");
                                 }
@@ -2796,15 +2815,11 @@ impl ApplicationHandler for App {
                                     state.canvas.clear_selection();
                                     log::info!("Redo performed");
                                     // Sync changes to collaborators
-                                    if state.collab.is_in_room() {
-                                        state.collab.sync_to_crdt(&state.canvas.document);
-                                        state.collab.broadcast_sync();
-                                        if let Some(ref ws) = state.websocket {
-                                            for msg in state.collab.take_outgoing() {
-                                                let _ = ws.send(&msg);
-                                            }
-                                        }
-                                    }
+                                    broadcast_doc_changes(
+                                        &mut state.collab,
+                                        &state.canvas.document,
+                                        state.websocket.as_ref(),
+                                    );
                                 } else {
                                     log::info!("Nothing to redo");
                                 }
@@ -3753,9 +3768,7 @@ impl ApplicationHandler for App {
                 let world_point = state.canvas.camera.screen_to_world(point);
 
                 // Update cursor based on hover position (only when not dragging)
-                if !state.input.is_button_pressed(MouseButton::Left)
-                    && !state.input.is_key_pressed(KeyCode::Space)
-                {
+                if !state.input.is_drawing() {
                     use drafftink_core::selection::{Corner, HandleKind};
                     let cursor = match state
                         .event_handler
@@ -3799,9 +3812,7 @@ impl ApplicationHandler for App {
 
                 // Handle dragging (manipulation or shape drawing).
                 // SPACE acts as a virtual left mouse button (Paint-style draw).
-                if state.input.is_button_pressed(MouseButton::Left)
-                    || state.input.is_key_pressed(KeyCode::Space)
-                {
+                if state.input.is_drawing() {
                     // Handle text selection dragging first
                     if let Some(text_id) = state.event_handler.editing_text {
                         if let Some(Shape::Text(text)) = state.canvas.document.get_shape(text_id) {
@@ -3832,14 +3843,12 @@ impl ApplicationHandler for App {
                             unsafe {
                                 DRAG_SYNC_FRAME = DRAG_SYNC_FRAME.wrapping_add(1);
                                 // Sync every 10 frames (~6 times per second at 60fps)
-                                if DRAG_SYNC_FRAME % 10 == 0 && state.collab.is_in_room() {
-                                    state.collab.sync_to_crdt(&state.canvas.document);
-                                    state.collab.broadcast_sync();
-                                    if let Some(ref ws) = state.websocket {
-                                        for msg in state.collab.take_outgoing() {
-                                            let _ = ws.send(&msg);
-                                        }
-                                    }
+                                if DRAG_SYNC_FRAME % 10 == 0 {
+                                    broadcast_doc_changes(
+                                        &mut state.collab,
+                                        &state.canvas.document,
+                                        state.websocket.as_ref(),
+                                    );
                                 }
                             }
                         }
@@ -4041,15 +4050,11 @@ impl ApplicationHandler for App {
                             );
 
                             // Broadcast document changes to collaborators
-                            if state.collab.is_in_room() {
-                                state.collab.sync_to_crdt(&state.canvas.document);
-                                state.collab.broadcast_sync();
-                                if let Some(ref ws) = state.websocket {
-                                    for msg in state.collab.take_outgoing() {
-                                        let _ = ws.send(&msg);
-                                    }
-                                }
-                            }
+                            broadcast_doc_changes(
+                                &mut state.collab,
+                                &state.canvas.document,
+                                state.websocket.as_ref(),
+                            );
 
                             // Clear snap guides when done dragging
                             state.event_handler.clear_snap();
@@ -4378,15 +4383,11 @@ impl ApplicationHandler for App {
                                 state.ui_state.angle_snap_enabled,
                             );
 
-                            if state.collab.is_in_room() {
-                                state.collab.sync_to_crdt(&state.canvas.document);
-                                state.collab.broadcast_sync();
-                                if let Some(ref ws) = state.websocket {
-                                    for msg in state.collab.take_outgoing() {
-                                        let _ = ws.send(&msg);
-                                    }
-                                }
-                            }
+                            broadcast_doc_changes(
+                                &mut state.collab,
+                                &state.canvas.document,
+                                state.websocket.as_ref(),
+                            );
 
                             state.event_handler.clear_snap();
                         }

--- a/crates/drafftink-app/src/app.rs
+++ b/crates/drafftink-app/src/app.rs
@@ -23,7 +23,7 @@ use winit::application::ApplicationHandler;
 use winit::dpi::LogicalSize;
 use winit::event::{ElementState, MouseButton, MouseScrollDelta, WindowEvent};
 use winit::event_loop::{ActiveEventLoop, EventLoop};
-use winit::keyboard::{Key, NamedKey};
+use winit::keyboard::{Key, KeyCode, NamedKey};
 use winit::window::{CursorIcon, Window, WindowId};
 
 use crate::event_handler::EventHandler;
@@ -3753,7 +3753,9 @@ impl ApplicationHandler for App {
                 let world_point = state.canvas.camera.screen_to_world(point);
 
                 // Update cursor based on hover position (only when not dragging)
-                if !state.input.is_button_pressed(MouseButton::Left) {
+                if !state.input.is_button_pressed(MouseButton::Left)
+                    && !state.input.is_key_pressed(KeyCode::Space)
+                {
                     use drafftink_core::selection::{Corner, HandleKind};
                     let cursor = match state
                         .event_handler
@@ -3795,8 +3797,11 @@ impl ApplicationHandler for App {
                     }
                 }
 
-                // Handle dragging (manipulation or shape drawing)
-                if state.input.is_button_pressed(MouseButton::Left) {
+                // Handle dragging (manipulation or shape drawing).
+                // SPACE acts as a virtual left mouse button (Paint-style draw).
+                if state.input.is_button_pressed(MouseButton::Left)
+                    || state.input.is_key_pressed(KeyCode::Space)
+                {
                     // Handle text selection dragging first
                     if let Some(text_id) = state.event_handler.editing_text {
                         if let Some(Shape::Text(text)) = state.canvas.document.get_shape(text_id) {
@@ -4337,6 +4342,56 @@ impl ApplicationHandler for App {
                             log::debug!("Text edit: unhandled key {:?}", event.logical_key);
                         }
                     }
+                    state.needs_redraw = true;
+                    state.window.request_redraw();
+                    return;
+                }
+
+                // SPACE behaves like the left mouse button for drawing
+                // (Paint-style: press to start, release to finish — uses the
+                // current cursor position). Modifier combos like Ctrl+Space
+                // are left to the regular handler below.
+                if matches!(&event.logical_key, Key::Named(NamedKey::Space))
+                    && !state.input.ctrl()
+                    && !event.repeat
+                {
+                    let position = state.input.mouse_position();
+                    let world_point = state.canvas.camera.screen_to_world(position);
+
+                    match event.state {
+                        ElementState::Pressed => {
+                            state.event_handler.handle_press(
+                                &mut state.canvas,
+                                world_point,
+                                &state.input,
+                                state.ui_state.grid_snap_enabled,
+                            );
+                        }
+                        ElementState::Released => {
+                            let current_style = state.ui_state.to_shape_style();
+                            state.event_handler.handle_release(
+                                &mut state.canvas,
+                                world_point,
+                                &state.input,
+                                &current_style,
+                                state.ui_state.grid_snap_enabled,
+                                state.ui_state.angle_snap_enabled,
+                            );
+
+                            if state.collab.is_in_room() {
+                                state.collab.sync_to_crdt(&state.canvas.document);
+                                state.collab.broadcast_sync();
+                                if let Some(ref ws) = state.websocket {
+                                    for msg in state.collab.take_outgoing() {
+                                        let _ = ws.send(&msg);
+                                    }
+                                }
+                            }
+
+                            state.event_handler.clear_snap();
+                        }
+                    }
+
                     state.needs_redraw = true;
                     state.window.request_redraw();
                     return;

--- a/crates/drafftink-app/src/shortcuts.rs
+++ b/crates/drafftink-app/src/shortcuts.rs
@@ -63,6 +63,12 @@ impl ShortcutRegistry {
             Shortcut::new("Backspace", false, false, "Delete selected shapes"),
             Shortcut::new("Escape", false, false, "Cancel current action"),
             Shortcut::new(
+                "Space",
+                false,
+                false,
+                "Draw / click at cursor (hold like the left mouse button)",
+            ),
+            Shortcut::new(
                 "Shift+Drag",
                 false,
                 false,

--- a/crates/drafftink-core/src/input.rs
+++ b/crates/drafftink-core/src/input.rs
@@ -133,6 +133,12 @@ impl InputState {
         self.helper.mouse_held(button)
     }
 
+    /// True while the user is actively drawing — left mouse button held,
+    /// or SPACE held (virtual left button for Paint-style keyboard drawing).
+    pub fn is_drawing(&self) -> bool {
+        self.helper.mouse_held(MouseButton::Left) || self.helper.key_held(KeyCode::Space)
+    }
+
     pub fn mouse_just_pressed(&self, button: MouseButton) -> bool {
         self.helper.mouse_pressed(button)
     }


### PR DESCRIPTION
## Why

Inspired by MS Paint: drawing in Paint with the keyboard's space bar held down is significantly more comfortable for long strokes than clicking-and-holding the left mouse button — your finger doesn't fatigue, and small/precise drags are easier because you're not also fighting the click pressure on the mouse button.

This PR brings the same affordance to drafft-ink: while a drawing tool is active, hold SPACE and move the mouse to draw, release SPACE to finish the shape. Anything that works with left-click works the same way with SPACE.

## Summary

- **d2374e3** — SPACE acts as a virtual left mouse button. Press starts a draw at the current cursor; release finishes it. Mirrors the mouse press/release flow so every tool (rectangle, line, freehand, …) is supported automatically.
- **9831513** — refactor pass:
  - Extract `broadcast_doc_changes()` — collapses 14 copy-pasted `is_in_room { sync_to_crdt; broadcast_sync; ws.send }` blocks. Implemented as a free function so callers inside the egui closure (which already borrows `state.egui_ctx`) can keep disjoint borrows of other `AppState` fields.
  - Add `InputState::is_drawing()` — owns the "left mouse OR space" rule in one place. Removes the OR-chains at the cursor-update and drag sites and gives a single seam for adding stylus/pen later.
- **a6b2a95** — match the SPACE press handler on `event.physical_key` instead of `event.logical_key`. The "is held" check (`is_drawing()`) already uses physical-key state via `winit_input_helper`; matching the press on logical key risked the two checks disagreeing on alternate layouts/IMEs where the space bar's logical output differs. Treat SPACE as the bar's position, not its character — closer to the Paint-style intent.

## Behavior details

- `Ctrl+Space` falls through to the regular keyboard handler (kept free for future bindings).
- `event.repeat` is filtered, so OS key auto-repeat doesn't re-fire press logic mid-stroke.
- Cursor hover updates are suppressed while SPACE is held (same as while the left button is held).
- Collab broadcast on release runs through the shared helper, so peers see the new shape immediately.

## Test plan

- [ ] Hold SPACE with the rectangle/line/ellipse/freehand tools — shape is drawn from cursor position on press to cursor position on release
- [ ] Release SPACE without moving — single-click behavior (e.g. text-tool placement)
- [ ] `Ctrl+Space` does not trigger a draw
- [ ] `cargo build --release` clean; `cargo clippy` no new warnings vs main
- [ ] Verify on a non-US keyboard layout that the physical-key match works (manual)
- [ ] Verify collab broadcast on release reaches peers (manual, two clients)
