### PR TITLE
Use relative WebSocket endpoint instead of localhost default

### DIFF
--- a/crates/drafftink-app/src/ui.rs
+++ b/crates/drafftink-app/src/ui.rs
@@ -328,7 +328,7 @@ impl Default for UiState {
             connection_state: ConnectionState::Disconnected,
             current_room: None,
             peer_count: 0,
-            server_url: "ws://localhost:3030/ws".to_string(),
+            server_url: "/ws".to_string(),
             room_input: String::new(),
             peers: Vec::new(),
             user_name: String::new(),
@@ -2214,7 +2214,7 @@ fn render_collaboration_modal(ctx: &Context, ui_state: &mut UiState) -> Option<U
                             ui,
                             &mut ui_state.server_url,
                             modal_width,
-                            "ws://localhost:3030/ws",
+                            "/ws",
                         );
 
                         ui.add_space(4.0);


### PR DESCRIPTION
This changes the default collaboration server URL from: ws://localhost:3030/ws

to: /ws

Why
The hardcoded localhost endpoint breaks self-hosted deployments where the frontend is served behind nginx or another reverse proxy. Browsers try connecting to the user's own localhost instead of the actual server.

Using a relative path allows the frontend to automatically use the current host and protocol through the reverse proxy configuration.

This fixes
- HTTPS deployments behind nginx
- Self-hosted static hosting setups
- Reverse proxy websocket forwarding
- Mixed-content issues from ws:// on https:// pages

Potential impact
- Deployments relying on the previous localhost default may need to explicitly configure their websocket endpoint
- Setups where the websocket server is hosted on a separate domain/path may still require manual override configuration

Tested with nginx reverse proxy setup using:
    location /ws