### PR TITLE
feat: Adopt useful parts of upstream PR (rex, wss://, auto-join)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -883,7 +883,7 @@ dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.9.4",
  "core-graphics-types 0.1.3",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -1784,12 +1784,21 @@ dependencies = [
 
 [[package]]
 name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared",
+ "foreign-types-shared 0.3.1",
 ]
 
 [[package]]
@@ -1802,6 +1811,12 @@ dependencies = [
  "quote",
  "syn 2.0.111",
 ]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -2954,7 +2969,7 @@ dependencies = [
  "bitflags 2.10.0",
  "block",
  "core-graphics-types 0.2.0",
- "foreign-types",
+ "foreign-types 0.5.0",
  "log",
  "objc",
  "paste",
@@ -3039,6 +3054,23 @@ dependencies = [
  "spirv",
  "thiserror 2.0.17",
  "unicode-ident",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -3508,6 +3540,50 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "openssl"
+version = "0.10.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "foreign-types 0.3.2",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.111"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "option-ext"
@@ -4212,7 +4288,7 @@ dependencies = [
 [[package]]
 name = "rex"
 version = "0.1.2"
-source = "git+https://github.com/KenyC/ReX#a779adebe63e70ef3b078090373c3af23c8b1083"
+source = "git+https://github.com/KenyC/ReX?rev=aeccdba38f3fa54195c469319b65c423e17a77ae#aeccdba38f3fa54195c469319b65c423e17a77ae"
 dependencies = [
  "log",
  "serde",
@@ -4356,6 +4432,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4378,6 +4463,29 @@ dependencies = [
  "memmap2",
  "smithay-client-toolkit 0.19.2",
  "tiny-skia",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.10.0",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -5173,6 +5281,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
+ "native-tls",
  "rand 0.8.5",
  "sha1",
  "thiserror 1.0.69",
@@ -5266,7 +5375,7 @@ checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 [[package]]
 name = "unicode-math"
 version = "0.1.0"
-source = "git+https://github.com/KenyC/ReX#a779adebe63e70ef3b078090373c3af23c8b1083"
+source = "git+https://github.com/KenyC/ReX?rev=aeccdba38f3fa54195c469319b65c423e17a77ae#aeccdba38f3fa54195c469319b65c423e17a77ae"
 dependencies = [
  "nom",
  "regex",
@@ -5359,6 +5468,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vello"

--- a/crates/drafftink-app/src/app.rs
+++ b/crates/drafftink-app/src/app.rs
@@ -1774,6 +1774,10 @@ pub struct App {
     /// Flag to indicate async init is in progress
     #[cfg(target_arch = "wasm32")]
     init_in_progress: std::cell::Cell<bool>,
+    /// Collaboration server URL to auto-connect to on startup (from CLI args).
+    startup_server: Option<String>,
+    /// Room to auto-join on startup (from CLI args).
+    startup_room: Option<String>,
 }
 
 impl App {
@@ -1791,13 +1795,18 @@ impl App {
             pending_window: None,
             #[cfg(target_arch = "wasm32")]
             init_in_progress: std::cell::Cell::new(false),
+            startup_server: None,
+            startup_room: None,
         }
     }
 
-    /// Run the application.
-    pub async fn run() {
+    /// Run the application, optionally auto-connecting to `server` and
+    /// auto-joining `room` on startup (native CLI args; `None` on the web).
+    pub async fn run(server: Option<String>, room: Option<String>) {
         let event_loop = EventLoop::new().expect("Failed to create event loop");
-        let app = App::new();
+        let mut app = App::new();
+        app.startup_server = server;
+        app.startup_room = room;
 
         #[cfg(target_arch = "wasm32")]
         {
@@ -1921,8 +1930,58 @@ impl App {
             self.try_auto_join_room();
         }
 
+        // Pre-populate collaboration fields from startup CLI args (native only).
+        #[cfg(not(target_arch = "wasm32"))]
+        if let Some(state) = self.state.as_mut() {
+            if let Some(server) = self.startup_server.as_ref() {
+                state.ui_state.server_url = server.clone();
+            }
+            if let Some(room) = self.startup_room.as_ref() {
+                state.ui_state.room_input = room.clone();
+            }
+        }
+
+        // Auto-connect (and optionally join a room) from startup args (native only).
+        #[cfg(not(target_arch = "wasm32"))]
+        if self.startup_server.is_some() {
+            self.try_auto_join_room_native();
+        }
+
         // Request initial redraw
         window.request_redraw();
+    }
+
+    /// Auto-connect to the startup server and queue a room join, driven by
+    /// native CLI args (`--server`/`--room`). Mirrors the WASM URL-param path.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn try_auto_join_room_native(&mut self) {
+        use drafftink_core::sync::ConnectionState;
+
+        let Some(server_url) = self.startup_server.clone() else {
+            return;
+        };
+        let room = self.startup_room.clone();
+        let Some(state) = self.state.as_mut() else {
+            return;
+        };
+
+        log::info!("Auto-connecting to {}", server_url);
+        let mut ws = drafftink_core::sync::NativeWebSocket::new();
+        match ws.connect(&server_url) {
+            Ok(()) => {
+                log::info!("WebSocket connecting to {}", server_url);
+                state.websocket = Some(ws);
+                state.ui_state.connection_state = ConnectionState::Connecting;
+                if let Some(room) = room {
+                    log::info!("Queuing auto-join for room '{}'", room);
+                    state.collab.join_room(&room);
+                }
+            }
+            Err(e) => {
+                log::error!("WebSocket connect failed: {}", e);
+                state.ui_state.connection_state = ConnectionState::Error;
+            }
+        }
     }
 
     /// Try to auto-join a room from URL parameters (WASM only).

--- a/crates/drafftink-app/src/main.rs
+++ b/crates/drafftink-app/src/main.rs
@@ -5,7 +5,32 @@ fn main() {
     env_logger::init();
     log::info!("Starting DrafftInk");
 
-    pollster::block_on(drafftink_app::App::run());
+    let (server, room) = parse_args();
+    pollster::block_on(drafftink_app::App::run(server, room));
+}
+
+/// Parse `--server <url>` and `--room <id>` from the command line so the
+/// desktop app can auto-connect and auto-join a collaboration room on startup.
+#[cfg(feature = "native")]
+fn parse_args() -> (Option<String>, Option<String>) {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let mut server = None;
+    let mut room = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--server" if i + 1 < args.len() => {
+                server = Some(args[i + 1].clone());
+                i += 2;
+            }
+            "--room" if i + 1 < args.len() => {
+                room = Some(args[i + 1].clone());
+                i += 2;
+            }
+            _ => i += 1,
+        }
+    }
+    (server, room)
 }
 
 #[cfg(not(feature = "native"))]

--- a/crates/drafftink-app/src/web.rs
+++ b/crates/drafftink-app/src/web.rs
@@ -132,6 +132,6 @@ pub async fn run_wasm() {
         log::info!("Server from URL: {}", server);
     }
 
-    // Run the app
-    crate::App::run().await;
+    // Run the app (web auto-joins via URL params, not CLI args)
+    crate::App::run(None, None).await;
 }

--- a/crates/drafftink-core/Cargo.toml
+++ b/crates/drafftink-core/Cargo.toml
@@ -22,7 +22,8 @@ pathfinding = "4"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 dirs = "5"
-tungstenite = "0.24"
+# native-tls enables wss:// (TLS) collaboration connections on desktop builds.
+tungstenite = { version = "0.24", features = ["native-tls"] }
 url = "2"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/crates/drafftink-core/src/sync.rs
+++ b/crates/drafftink-core/src/sync.rs
@@ -451,8 +451,10 @@ mod native_client {
                         log::info!("WebSocket connected, status: {}", response.status());
                         let _ = event_tx.send(SyncEvent::Connected);
 
-                        // Set read timeout on the underlying TCP stream for non-blocking behavior
-                        // This is more reliable for tunneled/forwarded connections
+                        // Set a read timeout on the underlying TCP stream so the
+                        // loop can interleave send-command checks with reads.
+                        // Without this, wss:// (TLS) connections block on read
+                        // indefinitely and never flush queued outgoing messages.
                         {
                             let stream = socket.get_mut();
                             match stream {
@@ -460,11 +462,15 @@ mod native_client {
                                     let _ = tcp.set_read_timeout(Some(Duration::from_millis(50)));
                                     let _ = tcp.set_write_timeout(Some(Duration::from_secs(5)));
                                 }
+                                tungstenite::stream::MaybeTlsStream::NativeTls(tls) => {
+                                    let tcp = tls.get_ref();
+                                    let _ = tcp.set_read_timeout(Some(Duration::from_millis(50)));
+                                    let _ = tcp.set_write_timeout(Some(Duration::from_secs(5)));
+                                }
                                 #[allow(unreachable_patterns)]
                                 _ => {
-                                    // For TLS streams, we'll rely on WouldBlock/TimedOut errors
-                                    log::debug!(
-                                        "TLS or other stream - using default timeout handling"
+                                    log::warn!(
+                                        "Unrecognized stream type - send commands may be delayed until the server sends data"
                                     );
                                 }
                             }

--- a/crates/drafftink-render/Cargo.toml
+++ b/crates/drafftink-render/Cargo.toml
@@ -26,7 +26,9 @@ vello = { workspace = true, optional = true }
 parley = { version = "0.7", optional = true, default-features = false, features = ["std"] }
 
 # Math rendering (ReX)
-rex = { git = "https://github.com/KenyC/ReX", features = ["ttfparser-fontparser"] }
+# Pinned to an immutable commit; aeccdba is required to build under Nix and is
+# the revision requested by the upstream contributor.
+rex = { git = "https://github.com/KenyC/ReX", rev = "aeccdba38f3fa54195c469319b65c423e17a77ae", features = ["ttfparser-fontparser"] }
 ttf-parser = "0.25"
 
 


### PR DESCRIPTION
Bring in the genuinely useful pieces of the upstream contribution while keeping the dependency footprint minimal and clear of the crate-age gate. The PR's broad `cargo update` (31 freshly published crates), the wgpu bump, and the Nix build are intentionally excluded.

Bump rex to KenyC/ReX@aeccdba, pinned to the immutable commit. Only rex and its unicode-math sibling change in the lockfile; every other pin is left exactly as it was on main.

Support wss:// collaboration on desktop by enabling tungstenite's native-tls feature and setting read/write timeouts on the NativeTls stream. Without the timeout the native client loop blocked on read indefinitely, so queued outgoing messages were never flushed. This adds only the mature native-tls dependency tree (openssl, schannel, security-framework, ...), all well past the age gate.

Add desktop auto-join via `--server` and `--room` CLI args, threaded through App::run; the web build continues to auto-join from URL params.